### PR TITLE
remove backports in configParser

### DIFF
--- a/excalibur/configuration.py
+++ b/excalibur/configuration.py
@@ -1,7 +1,7 @@
 import os
 
 import six
-from backports.configparser import ConfigParser
+from configparser import ConfigParser
 
 
 def _read_default_config_file(file_name):


### PR DESCRIPTION
Update to make it python 3.10 compatible. 

> NOTE: Missing to update `version` and `changelog` 